### PR TITLE
remove X-Frame-Options SAMEORIGIN header

### DIFF
--- a/infra/roles/nginx/templates/rshiny-site-https.j2
+++ b/infra/roles/nginx/templates/rshiny-site-https.j2
@@ -1,4 +1,3 @@
-add_header X-Frame-Options SAMEORIGIN;
 add_header X-Content-Type-Options nosniff;
 add_header X-XSS-Protection "1; mode=block";
 


### PR DESCRIPTION
... to enable embedding of shiny pages in iframe of marinedata-dev